### PR TITLE
Restructure routing for separation among endpoints

### DIFF
--- a/config/secrets.js
+++ b/config/secrets.js
@@ -1,0 +1,7 @@
+/*
+ * You generally want to .gitignore this file to prevent important credentials from being stored on your public repo.
+ */
+module.exports = {
+    token : "secret-llama",
+    mongo_connection : "mongodb://localhost/mp4"
+};

--- a/routes/home.js
+++ b/routes/home.js
@@ -1,0 +1,14 @@
+var secrets = require('../config/secrets');
+
+module.exports = function(router) {
+
+  var homeRoute = router.route('/');
+
+  homeRoute.get(function(req, res) {
+    connectionString = secrets.token;
+    res.json({ message: 'My connection string is ' + connectionString });
+  });
+
+  return router;
+}
+

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,7 @@
+/*
+ * Connect all of your endpoints together here.
+ */
+module.exports = function (app, router) {
+  app.use('/api', require('./home.js')(router));
+  app.use('/api', require('./llama.js')(router));
+};

--- a/routes/llama.js
+++ b/routes/llama.js
@@ -1,0 +1,15 @@
+var secrets = require('../config/secrets');
+var Llama = require('../models/llama');
+
+module.exports = function(router) {
+
+  var llamaRoute = router.route('/llamas');
+  
+  llamaRoute.get(function(req, res) {
+    res.json([{ "name": "alice", "height": 12 }, { "name": "jane", "height": 13 }]);
+  });
+
+  return router;
+}
+
+

--- a/server.js
+++ b/server.js
@@ -1,18 +1,13 @@
 // Get the packages we need
 var express = require('express');
-var mongoose = require('mongoose');
-var Llama = require('./models/llama');
-var bodyParser = require('body-parser');
 var router = express.Router();
-
-//replace this with your Mongolab URL
-mongoose.connect('mongodb://localhost/mp4');
+var bodyParser = require('body-parser');
 
 // Create our Express application
 var app = express();
 
-// Use environment defined port or 4000
-var port = process.env.PORT || 4000;
+// Use environment defined port or 3000
+var port = process.env.PORT || 3000;
 
 //Allow CORS so that backend and frontend could pe put on different servers
 var allowCrossDomain = function(req, res, next) {
@@ -27,24 +22,8 @@ app.use(bodyParser.urlencoded({
   extended: true
 }));
 
-// All our routes will start with /api
-app.use('/api', router);
-
-//Default route here
-var homeRoute = router.route('/');
-
-homeRoute.get(function(req, res) {
-  res.json({ message: 'Hello World!' });
-});
-
-//Llama route
-var llamaRoute = router.route('/llamas');
-
-llamaRoute.get(function(req, res) {
-  res.json([{ "name": "alice", "height": 12 }, { "name": "jane", "height": 13 }]);
-});
-
-//Add more routes here
+// Use routes as a module (see index.js)
+require('./routes')(app, router);
 
 // Start the server
 app.listen(port);


### PR DESCRIPTION
It's hard to read code when you have all of your endpoints defined in `server.js`.

The starter should be restructured so that new endpoints can be defined in separate files and connected easily with express.