### PR TITLE
Add bodyParser.json and more CORS headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ var port = process.env.PORT || 3000;
 var allowCrossDomain = function(req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
   res.header("Access-Control-Allow-Headers", "X-Requested-With, X-HTTP-Method-Override, Content-Type, Accept");
+  res.header("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
   next();
 };
 app.use(allowCrossDomain);
@@ -21,6 +22,8 @@ app.use(allowCrossDomain);
 app.use(bodyParser.urlencoded({
   extended: true
 }));
+
+app.use(bodyParser.json());
 
 // Use routes as a module (see index.js)
 require('./routes')(app, router);


### PR DESCRIPTION
One student wasn't able to connect his MP4_client with his server because he was missing:

1) CORS headers
2) Telling app to use bodyParser.json

I just added these